### PR TITLE
Fix 'composer suggests' command output

### DIFF
--- a/1.3/apache/Dockerfile
+++ b/1.3/apache/Dockerfile
@@ -100,7 +100,7 @@ RUN curl -fL -o /tmp/roundcube.tar.gz \
  # Resolve Roudcube Composer dependencies
  && mv /app/composer.json-dist /app/composer.json \
  && cd /app/ \
- && (/tmp/composer suggests | xargs -i /tmp/composer require {}) \
+ && (/tmp/composer suggests --list | xargs -i /tmp/composer require {}) \
  && /tmp/composer install --no-dev --optimize-autoloader --no-progress \
     \
  # Resolve Roudcube JS dependencies

--- a/1.3/fpm/Dockerfile
+++ b/1.3/fpm/Dockerfile
@@ -82,7 +82,7 @@ RUN curl -fL -o /tmp/roundcube.tar.gz \
  # Resolve Roudcube Composer dependencies
  && mv /app/composer.json-dist /app/composer.json \
  && cd /app/ \
- && (/tmp/composer suggests | xargs -i /tmp/composer require {}) \
+ && (/tmp/composer suggests --list | xargs -i /tmp/composer require {}) \
  && /tmp/composer install --no-dev --optimize-autoloader --no-progress \
     \
  # Resolve Roudcube JS dependencies

--- a/1.4/apache/Dockerfile
+++ b/1.4/apache/Dockerfile
@@ -96,7 +96,7 @@ RUN curl -fL -o /tmp/roundcube.tar.gz \
  # Resolve Roudcube Composer dependencies
  && mv /app/composer.json-dist /app/composer.json \
  && cd /app/ \
- && (/tmp/composer suggests | xargs -i /tmp/composer require {}) \
+ && (/tmp/composer suggests --list | xargs -i /tmp/composer require {}) \
  && /tmp/composer install --no-dev --optimize-autoloader --no-progress \
     \
  # Resolve Roudcube JS dependencies

--- a/1.4/fpm/Dockerfile
+++ b/1.4/fpm/Dockerfile
@@ -82,7 +82,7 @@ RUN curl -fL -o /tmp/roundcube.tar.gz \
  # Resolve Roudcube Composer dependencies
  && mv /app/composer.json-dist /app/composer.json \
  && cd /app/ \
- && (/tmp/composer suggests | xargs -i /tmp/composer require {}) \
+ && (/tmp/composer suggests --list | xargs -i /tmp/composer require {}) \
  && /tmp/composer install --no-dev --optimize-autoloader --no-progress \
     \
  # Resolve Roudcube JS dependencies

--- a/Dockerfile.tmpl.php
+++ b/Dockerfile.tmpl.php
@@ -165,7 +165,7 @@ RUN curl -fL -o /tmp/roundcube.tar.gz \
  # Resolve Roudcube Composer dependencies
  && mv /app/composer.json-dist /app/composer.json \
  && cd /app/ \
- && (/tmp/composer suggests | xargs -i /tmp/composer require {}) \
+ && (/tmp/composer suggests --list | xargs -i /tmp/composer require {}) \
  && /tmp/composer install --no-dev --optimize-autoloader --no-progress \
     \
  # Resolve Roudcube JS dependencies


### PR DESCRIPTION
FCM
```
Fix 'composer suggests' command output (#8)

- add option '--list' to restore previous behavior of command
```

Behavior of  'composer suggests'  has been changed since [commit][1] (apparently composer 2.0.0).

Now command is verbose by default and that breaks build script.       
It requires option  '--list'  to restore previous behavior: Show only list of suggested package names.

[1]: https://github.com/composer/composer/commit/44d1e15294058129b4b27008d3d0ffb25a896c15
